### PR TITLE
Add the way to set filename explicitly so we can initialize from data-url or blob and operate successfully

### DIFF
--- a/src/ImageManipulation.js
+++ b/src/ImageManipulation.js
@@ -154,7 +154,9 @@ export class ImageManipulation {
             if (this._tasks[i].type === LOADER) {
                 let data = await this._tasks[i].func()
                 this._loadedCanvas = data.canvas
-                this._fileName = data.fileName
+                if (data.fileName) {
+                    this._fileName = data.fileName;
+                }
             } else {
                 if (this._canvas === null && this._loadedCanvas === null) {
                     throw new Error('use loadBlob first')
@@ -196,6 +198,14 @@ export class ImageManipulation {
      */
     getFileName () {
         return this._fileName
+    }
+
+    /**
+     *
+     * @param newFileName - New filename to be used in mime type definition
+     */
+    setFileName (newFileName) {
+        this._fileName = newFileName;
     }
 
     /**


### PR DESCRIPTION
Use case:
```
  const im = new ImageManipulation();
  await im.loadBlob(oldData.blob);
  await im.rotate(angle);
  im.setFileName(oldData.fileName);
  const newBlob = await im.saveAsBlob();
  const newDataUrl = await im.saveAsImage();
  const newSize = await browserImageSize(newBlob);
```