### PR TITLE
Add feature allowing to crop down to specified size

### DIFF
--- a/src/ImageManipulation.js
+++ b/src/ImageManipulation.js
@@ -1,6 +1,6 @@
 import {loadBlob} from './loaders/loadBlob.js'
 import {loadCanvas} from './loaders/loadCanvas.js'
-import {imageResize} from './manipulations/imageResize.js'
+import {imageCrop, imageResize} from './manipulations/imageResize.js'
 import {rotate} from './manipulations/rotate.js'
 import {centerInRectangle} from './manipulations/centerInRectangle.js'
 import {circle} from './manipulations/circle.js'
@@ -63,6 +63,16 @@ export class ImageManipulation {
      */
     toSquare (length = 150, opts = {}) {
         return this._imageResize(length, length, RESIZE_TYPE_SQUARE, opts)
+    }
+
+    /**
+     * @param width {number} - width to crop to.
+     * @param height {number} - height to crop to.
+     * @returns {ImageManipulation}
+     */
+    crop (maxWidth, maxHeight) {
+        this._addToTask(MANIPULATION, imageCrop(maxWidth, maxHeight))
+        return this
     }
 
     /**

--- a/src/manipulations/imageResize.js
+++ b/src/manipulations/imageResize.js
@@ -3,6 +3,34 @@ import Pica from 'pica/dist/pica'
 import {RESIZE_TYPE_SQUARE, RESIZE_TYPE_TO} from '../constants'
 
 /**
+ * @param newWidth{number} - new width after crop.
+ * @param newHeight{number} - new height after crop.
+ * @returns {function(*=): Promise<HTMLCanvasElement>}
+ */
+ export function imageCrop(newWidth, newHeight) {
+    return (canvasImage) => new Promise((resolve, reject) => {
+        let dx = 0
+        let dy = 0
+        let sx = 0
+        let sy = 0
+        let width = canvasImage.width
+        let height = canvasImage.height
+
+        sy = (height - newHeight) / 2
+        sx = (width - newWidth) / 2
+
+        let cropedCanvas = document.createElement('canvas')
+        let cropedCanvasCtx = cropedCanvas.getContext('2d')
+        cropedCanvas.width = newWidth
+        cropedCanvas.height = newHeight
+
+        cropedCanvasCtx.drawImage(canvasImage, sx, sy, newWidth, newHeight, dx, dy, newWidth, newHeight)
+
+        resolve(cropedCanvas)
+    })
+ }
+
+/**
  * @param maxWidth
  * @param maxHeight
  * @param type


### PR DESCRIPTION
Hi. I think this feature will be useful for simple image cropping. We use that type of cropping for enforcing specific aspect ratio before uploading to Instagram or other social media.

Use case: 
```
const crop = async (oldData: FileInputDataT, cropSize: SizeT): Promise<FileInputDataT> => {
  const im = new ImageManipulation();
  await im.loadBlob(oldData.blob);
  await im.crop(cropSize.width, cropSize.height);
  im.setFileName(oldData.fileName);
  const newBlob = await im.saveAsBlob();
  const newDataUrl = await im.saveAsImage();
  const newSize = await browserImageSize(newBlob);


  return {
    dataUrl:  newDataUrl,
    fileName: oldData.fileName,
    fileType: oldData.fileType,
    size:     newSize,
    blob:     newBlob,
  };
};
```

